### PR TITLE
fix redis enableTLS config yaml key name

### DIFF
--- a/cmd/registry/config-cache.yml
+++ b/cmd/registry/config-cache.yml
@@ -21,7 +21,7 @@ http:
         X-Content-Type-Options: [nosniff]
 redis:
   addr: localhost:6379
-  enabletls: true
+  enableTLS: true
   pool:
     maxidle: 16
     maxactive: 64

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -177,7 +177,7 @@ type Configuration struct {
 		// DB specifies the database to connect to on the redis instance.
 		DB int `yaml:"db,omitempty"`
 
-		EnableTLS bool `yaml:"enabletls,omitempty"`
+		EnableTLS bool `yaml:"enableTLS,omitempty"`
 
 		DialTimeout  time.Duration `yaml:"dialtimeout,omitempty"`  // timeout for connect
 		ReadTimeout  time.Duration `yaml:"readtimeout,omitempty"`  // timeout for reads of data


### PR DESCRIPTION
fix: https://github.com/goharbor/harbor/issues/21913

registry config.yml
```
redis:
  # sentinel hosts with comma
  addr: xx.xxx.xx.xx:30013,xx.xxx.xx.xx:30014,xx.xxx.xx.xx:30015
  sentinelMasterSet: mymaster
  readtimeout: 10s
  writetimeout: 10s
  dialtimeout: 10s
  password: 12345
  db: 1
  enableTLS: true
  pool:
    maxidle: 100
    maxactive: 500
    idletimeout: 60s
```

redis data
```
[1]> keys *
1) "upload:4272a3db-8930-438c-8030-56bb38d12340:size"
2) "blobs::sha256:7565f2c7034d87673c5ddc3b1b8e97f8da794c31d9aa73ed26afffa1c8194889"
3) "repository::library/hello-world::blobs::sha256:74cc54e27dc41bb10dc4b2226072d469509f2f22f1a3ce74f4a59661a1d44602"
4) "blobs::sha256:74cc54e27dc41bb10dc4b2226072d469509f2f22f1a3ce74f4a59661a1d44602"
5) "blobs::sha256:e6590344b1a5dc518829d6ea1524fc12f8bcd14ee9a02aa6ad8360cce3a9a9e9"
6) "repository::library/hello-world::blobs::sha256:e6590344b1a5dc518829d6ea1524fc12f8bcd14ee9a02aa6ad8360cce3a9a9e9"
7) "upload:c86e2bc0-74ac-42c4-b896-90cdbfab3cc4:size"
8) "repository::library/hello-world::blobs"
```

registry log
```
time="2025-04-23T08:24:29.454091964Z" level=info msg="redis: connect  xx.xxx.xx.xx:30013, xx.xxx.xx.xx:30014, xx.xxx.xx.xx:30015" go.version=go1.23.8 instance.id=5db6019a-d15f-4aa1-ba47-995377f025a6 redis.connect.duration=249.503578ms service=registry version=8f364e29 
172.18.0.8 - - [23/Apr/2025:08:24:29 +0000] "PUT /v2/library/hello-world/blobs/uploads/4272a3db-8930-438c-8030-56bb38d12340?_state=oFNqQOu99qO1EvDe9kjJxPzgrc2d1equTq5T6qddnHF7Ik5hbWUiOiJsaWJyYXJ5L2hlbGxvLXdvcmxkIiwiVVVJRCI.... HTTP/1.1" 201 0 "" "docker/28.1.1 go/go1.23.8 git-commit/01f442b kernel/6.8.0-57-generic os/linux arch/amd64 UpstreamClient(Docker-Client/28.1.1 \\(linux\\))"
```