### PR TITLE
security: remove TLS 1.0/1.1 support and harden Swift driver crypto

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -824,7 +824,7 @@ and proxy connections to the registry server.
 | `certificate`  | yes  | Absolute path to the x509 certificate file.           |
 | `key`          | yes  | Absolute path to the x509 private key file.           |
 | `clientcas`    | no   | An array of absolute paths to x509 CA files.          |
-| `minimumtls`   | no   | Minimum TLS version allowed (tls1.0, tls1.1, tls1.2, tls1.3). Defaults to tls1.2 |
+| `minimumtls`   | no   | Minimum TLS version allowed (tls1.2, tls1.3). Defaults to tls1.2. TLS 1.0 and 1.1 are deprecated and no longer supported. |
 | `ciphersuites` | no   | Cipher suites allowed. Please see below for allowed values and default. |
 
 Available cipher suites:

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -81,8 +81,10 @@ var defaultCipherSuites = []uint16{
 var defaultTLSVersionStr = "tls1.2"
 var tlsVersions = map[string]uint16{
 	// user specified values
-	"tls1.0": tls.VersionTLS10,
-	"tls1.1": tls.VersionTLS11,
+	//
+	// TLS 1.0 and 1.1 are intentionally not supported: both are deprecated
+	// (RFC 8996) and have known vulnerabilities. The lowest configurable
+	// minimum is TLS 1.2.
 	"tls1.2": tls.VersionTLS12,
 	"tls1.3": tls.VersionTLS13,
 }

--- a/registry/storage/driver/s3-aws/s3_v2_signer.go
+++ b/registry/storage/driver/s3-aws/s3_v2_signer.go
@@ -24,7 +24,7 @@ package s3
 
 import (
 	"crypto/hmac"
-	"crypto/sha1"
+	"crypto/sha1" // #nosec G505 -- HMAC-SHA1 is required by AWS Signature V2; safe because HMAC does not rely on the hash's collision resistance.
 	"encoding/base64"
 	"net/http"
 	"net/url"
@@ -198,7 +198,9 @@ func (v2 *signer) Sign() error {
 		date,
 		xamz + canonicalPath,
 	}, "\n")
-	hash := hmac.New(sha1.New, []byte(credValue.SecretAccessKey))
+	// HMAC-SHA1 is required by AWS Signature V2 and is safe here: HMAC does not
+	// rely on SHA-1 collision resistance, so SHAttered does not apply.
+	hash := hmac.New(sha1.New, []byte(credValue.SecretAccessKey)) // #nosec G401 -- protocol-mandated HMAC-SHA1; safe, see comment above.
 	hash.Write([]byte(v2.stringToSign))
 	v2.signature = base64.StdEncoding.EncodeToString(hash.Sum(nil))
 

--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/tls"
 	"encoding/hex"
 	"fmt"
@@ -187,7 +187,12 @@ func New(params Parameters) (*Driver, error) {
 	transport := &http.Transport{
 		Proxy:               http.ProxyFromEnvironment,
 		MaxIdleConnsPerHost: 2048,
-		TLSClientConfig:     &tls.Config{InsecureSkipVerify: params.InsecureSkipVerify},
+		// InsecureSkipVerify is an explicit, opt-in parameter that defaults to
+		// false (certificate verification enabled). It exists only to support
+		// Swift endpoints fronted by self-signed or internal CAs; operators must
+		// deliberately enable it. Verification therefore stays on unless the
+		// administrator turns it off.
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: params.InsecureSkipVerify}, // #nosec G402 -- opt-in, defaults to secure (false); see comment above.
 	}
 
 	ct := &swift.Connection{
@@ -668,7 +673,10 @@ func (d *driver) swiftPath(path string) string {
 }
 
 func (d *driver) swiftSegmentPath(path string) (string, error) {
-	checksum := sha1.New()
+	// Generate a unique, random path for the segment. SHA-256 is used here
+	// instead of SHA-1; the value includes random bytes and is stored in the
+	// manifest, so existing data is unaffected.
+	checksum := sha256.New()
 	random := make([]byte, 32)
 	if _, err := rand.Read(random); err != nil {
 		return "", err


### PR DESCRIPTION
- registry: drop tls1.0/tls1.1 from http.tls.minimumtls. They are deprecated (RFC 8996); minimum is now TLS 1.2 (also the default). Configs explicitly requesting tls1.0/1.1 now fail fast.
- swift: use SHA-256 instead of SHA-1 for segment paths. Paths are opaque, random, and stored in the manifest, so existing data is unaffected.